### PR TITLE
Update UML `UiClassDiagram` in DG to include TodayDelivery classes

### DIFF
--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -3,6 +3,8 @@
 skinparam arrowThickness 1.1
 skinparam arrowColor UI_COLOR_T4
 skinparam classBackgroundColor UI_COLOR
+skinparam nodesep 40
+skinparam ranksep 75
 
 package UI <<Rectangle>>{
 Class "<<interface>>\nUi" as Ui
@@ -13,6 +15,8 @@ Class HelpWindow
 Class ResultDisplay
 Class PersonListPanel
 Class PersonCard
+Class TodayDeliveryPanel
+Class TodayDeliveryCard
 Class StatusBarFooter
 Class CommandBox
 }
@@ -33,10 +37,12 @@ UiManager -down-> "1" MainWindow
 MainWindow *-down->  "1" CommandBox
 MainWindow *-down-> "1" ResultDisplay
 MainWindow *-down-> "1" PersonListPanel
+MainWindow *-down-> "1" TodayDeliveryPanel
 MainWindow *-down-> "1" StatusBarFooter
 MainWindow --> "0..1" HelpWindow
 
 PersonListPanel -down-> "*" PersonCard
+TodayDeliveryPanel -down-> "*" TodayDeliveryCard
 
 MainWindow -left-|> UiPart
 
@@ -44,13 +50,17 @@ ResultDisplay --|> UiPart
 CommandBox --|> UiPart
 PersonListPanel --|> UiPart
 PersonCard --|> UiPart
+TodayDeliveryPanel --|> UiPart
+TodayDeliveryCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
 
 PersonCard ..> Model
+TodayDeliveryCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic
 
+TodayDeliveryPanel -[hidden]left- PersonListPanel
 PersonListPanel -[hidden]left- HelpWindow
 HelpWindow -[hidden]left- CommandBox
 CommandBox -[hidden]left- ResultDisplay


### PR DESCRIPTION
Closes #156 

**Updated UiClassDiagram**
<img width="1321" height="663" alt="image" src="https://github.com/user-attachments/assets/c255daea-98e4-4cb6-a84f-4f628085bf32" />

PlantUML has an issue with overlapping arrowheads, even after increasing the spacing between the Classes and levels.
If anyone has suggestions on how to fix this, please let me know! 