### PR TITLE
Clarify `find-delivery` boundary conditions in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -230,7 +230,7 @@ The following sequence diagram illustrates the interactions within the `Logic` c
 #### Design considerations
 
 1. How `find-delivery` accepts date input.
-    * **Chosen:** Support both a single date (`dt/`) and a date range (`st/` and `ed/`, inclusive of both `START_DATE` and `END_DATE`), but not both at the same time.
+    * **Chosen:** Support both a single date (`dt/`) and a date range (`st/` and `ed/`), but not both at the same time. The date range is inclusive of both `START_DATE` and `END_DATE`.
         * Pros: Flexible; covers the common case of checking a single day as well as planning for a longer window.
         * Cons: Parser must validate that the two modes are mutually exclusive, adding some complexity.
     * **Alternative:** Accept only a single date.


### PR DESCRIPTION
Fixes #294 