### PR TITLE
Fix `ScheduleSequenceDiagram`

### DIFF
--- a/docs/diagrams/ScheduleSequenceDiagram.puml
+++ b/docs/diagrams/ScheduleSequenceDiagram.puml
@@ -89,4 +89,5 @@ deactivate ScheduleCommand
 
 [<--LogicManager
 deactivate LogicManager
+destroy ScheduleCommand
 @enduml


### PR DESCRIPTION
Closes #370.

Updated `ScheduleSequenceDiagram`:
<img width="2354" height="1115" alt="image" src="https://github.com/user-attachments/assets/292d003a-49f9-4acf-87e4-f59d5cd23e33" />
